### PR TITLE
Remove target.wasm32-unknown-unknown section from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,5 @@ console_error_panic_hook = "0.1"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 
-[target.wasm32-unknown-unknown]
-runner = 'wasm-bindgen-test-runner'
-
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
This causes cargo to print a warning:

> warning: unused manifest key: target.wasm32-unknown-unknown.runner

Looks like you've already added it to the right place (`.cargo/config.toml`) as well.